### PR TITLE
[SPARK-GREENPLUM-4]Add transactions support for transmitting data to greenplum. #8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
             <version>9.6.3-3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <outputDirectory>target/scala-${scala.binary.ver}/classes</outputDirectory>

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.jdbc._
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister, RelationProvider}
+import org.apache.spark.sql.types.StructType
 
 class DefaultSource
   extends RelationProvider with CreatableRelationProvider with DataSourceRegister {
@@ -64,33 +65,54 @@ class DefaultSource
       df: DataFrame): BaseRelation = {
     val options =
       GreenplumOptions(CaseInsensitiveMap(parameters), sqlContext.conf.sessionLocalTimeZone)
+    val isCaseSensitive = sqlContext.conf.caseSensitiveAnalysis
+
     val conn = createConnectionFactory(options)()
     try {
       if (tableExists(conn, options)) {
+        // In fact, the mode here is Overwrite constantly, we add other modes just for compatible.
         mode match {
           case SaveMode.Overwrite
             if options.isTruncate && isCascadingTruncateTable(options.url).contains(false) =>
+            val tableSchema = getSchemaOption(conn, options)
+            checkSchema(tableSchema, df.schema, isCaseSensitive)
             truncateTable(conn, options)
-            val tableSchema = getSchemaOption(conn, options).getOrElse(df.schema)
-            copyToGreenplum(df, tableSchema, options)
+            copyToGreenplum(df, tableSchema.getOrElse(df.schema), options, true)
           case SaveMode.Overwrite =>
-            dropTable(conn, options.table)
-            createTable(conn, df, options)
-            copyToGreenplum(df, df.schema, options)
+            copyToGreenplum(df, df.schema, options, false)
           case SaveMode.Append =>
-            val tableSchema = getSchemaOption(conn, options).getOrElse(df.schema)
-            copyToGreenplum(df, tableSchema, options)
+            val tableSchema = getSchemaOption(conn, options)
+            checkSchema(tableSchema, df.schema, isCaseSensitive)
+            copyToGreenplum(df, tableSchema.getOrElse(df.schema), options, true)
           case SaveMode.ErrorIfExists =>
             throw new AnalysisException(s"Table or view '${options.table}' already exists. $mode")
           case SaveMode.Ignore => // do nothing
         }
       } else {
-        createTable(conn, df, options)
-        copyToGreenplum(df, df.schema, options)
+        copyToGreenplum(df, df.schema, options, false)
       }
     } finally {
       conn.close()
     }
     createRelation(sqlContext, parameters)
+  }
+
+  private def checkSchema(
+      tableSchema: Option[StructType],
+      dfSchema: StructType,
+      isCaseSensitive: Boolean): Unit = {
+    if (!tableSchema.isEmpty) {
+      val columnNameEquality = if (isCaseSensitive) {
+        org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution
+      } else {
+        org.apache.spark.sql.catalyst.analysis.caseInsensitiveResolution
+      }
+      val tableColumnNames = tableSchema.get.fieldNames
+      dfSchema.fields.map { col =>
+        tableColumnNames.find(f => columnNameEquality(f, col.name)).getOrElse(
+          throw new AnalysisException(s"Column ${col.name} not found int schema $tableSchema.")
+        )
+      }
+    }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
@@ -77,15 +77,13 @@ class DefaultSource
             val tableSchema = getSchemaOption(conn, options)
             checkSchema(tableSchema, df.schema, isCaseSensitive)
             truncateTable(conn, options)
-            val finaldf = df.coalesce(1)
-            copyAppendToGreenplum(finaldf, tableSchema.getOrElse(finaldf.schema), options)
+            copyAppendToGreenplum(df, tableSchema.getOrElse(df.schema), options)
           case SaveMode.Overwrite =>
             copyOverwriteToGreenplum(df, df.schema, options)
           case SaveMode.Append =>
             val tableSchema = getSchemaOption(conn, options)
             checkSchema(tableSchema, df.schema, isCaseSensitive)
-            val finaldf = df.coalesce(1)
-            copyAppendToGreenplum(finaldf, tableSchema.getOrElse(finaldf.schema), options)
+            copyAppendToGreenplum(df, tableSchema.getOrElse(df.schema), options)
           case SaveMode.ErrorIfExists =>
             throw new AnalysisException(s"Table or view '${options.table}' already exists. $mode")
           case SaveMode.Ignore => // do nothing

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -35,7 +35,12 @@ case class GreenplumOptions(
   val delimiter: String = params.getOrElse("delimiter", ",")
   assert(delimiter.length == 1, "The delimiter should be a single character.")
 
-  val transactionForAppend: Boolean = params.getOrElse("transactionForAppend", "false").toBoolean
+  /**
+   * This option is only used for these cases:
+   * 1. overwrite a gptable, which is a CascadingTruncateTable.
+   * 2. append data to a gptable.
+   */
+  val transactionOn: Boolean = params.getOrElse("transactionOn", "false").toBoolean
 
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(
     params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -35,8 +35,7 @@ case class GreenplumOptions(
   val delimiter: String = params.getOrElse("delimiter", ",")
   assert(delimiter.length == 1, "The delimiter should be a single character.")
 
-  val transactionForAppend: Boolean =
-    params.getOrElse("transactionForAppend", "false").equals("true")
+  val transactionForAppend: Boolean = params.getOrElse("transactionForAppend", "false").toBoolean
 
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(
     params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -33,6 +33,7 @@ case class GreenplumOptions(
   extends JDBCOptions(params.updated("driver", "org.postgresql.Driver")) {
 
   val delimiter: String = params.getOrElse("delimiter", ",")
+  assert(delimiter.length == 1, "The delimiter should be a single character.")
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(
     params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -34,6 +34,10 @@ case class GreenplumOptions(
 
   val delimiter: String = params.getOrElse("delimiter", ",")
   assert(delimiter.length == 1, "The delimiter should be a single character.")
+
+  val transactionForAppend: Boolean =
+    params.getOrElse("transactionForAppend", "false").equals("true")
+
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(
     params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -42,6 +42,9 @@ case class GreenplumOptions(
    */
   val transactionOn: Boolean = params.getOrElse("transactionOn", "false").toBoolean
 
+  /** Max number of times we are allowed to retry dropTempTable operation. */
+  val dropTempTableMaxRetries: Int = 3
+
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(
     params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumRelation.scala
@@ -67,18 +67,15 @@ private[sql] case class GreenplumRelation(
       if (overwrite) {
         if (options.isTruncate && isCascadingTruncateTable(options.url).contains(false)) {
           truncateTable(conn, options)
-          copyToGreenplum(data, schema, options)
+          copyToGreenplum(data, schema, options, true)
         } else {
-          dropTable(conn, options.table)
-          createTable(conn, data, options)
-          copyToGreenplum(data, schema, options)
+          copyToGreenplum(data, schema, options, false)
         }
       } else {
-        copyToGreenplum(data, schema, options)
+        copyToGreenplum(data, schema, options, true)
       }
     } else {
-      createTable(conn, data, options)
-      copyToGreenplum(data, schema, options)
+      copyToGreenplum(data, schema, options, false)
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumRelation.scala
@@ -68,14 +68,12 @@ private[sql] case class GreenplumRelation(
         if (overwrite) {
           if (options.isTruncate && isCascadingTruncateTable(options.url).contains(false)) {
             truncateTable(conn, options)
-            val finaldata = data.coalesce(1)
-            copyAppendToGreenplum(finaldata, schema, options)
+            copyAppendToGreenplum(data, schema, options)
           } else {
             copyOverwriteToGreenplum(data, schema, options)
           }
         } else {
-          val finaldata = data.coalesce(1)
-          copyAppendToGreenplum(finaldata, schema, options)
+          copyAppendToGreenplum(data, schema, options)
         }
       } else {
         copyOverwriteToGreenplum(data, schema, options)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -173,7 +173,7 @@ object GreenplumUtils extends Logging {
       options: GreenplumOptions,
       schema: StructType,
       tableName: String,
-      accumulator: LongAccumulator = null): Unit = {
+      accumulator: LongAccumulator): Unit = {
     val valueConverters: Array[(Row, Int) => String] =
       schema.map(s => makeConverter(s.dataType, options)).toArray
     val conn = JdbcUtils.createConnectionFactory(options)()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -128,8 +128,13 @@ object GreenplumUtils extends Logging {
       } else {
         val dropTempTbl = s"DROP TABLE $tempTable"
         executeStatement(conn, dropTempTbl)
+
         throw new PartitionCopyFailureException(
-          s"Some partitions failed(successful: ${accumulator.value}, total: $partNum)")
+          s"""
+          | Job aborted for that there are some partitions failed to copy data to greenPlum:
+          | Total partitions is: ${partNum}, and successful partitions is: ${accumulator.value}.
+          | You can retry again.
+          """.stripMargin)
       }
     } finally {
       closeConnSilent(conn)

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -68,9 +68,10 @@ object GreenplumUtils extends Logging {
       valueConverters: Array[(Row, Int) => String]): Array[Byte] = {
     var i = 0
     val values = new Array[String](schema.length)
+    val delimiter = options.delimiter.charAt(0)
     while (i < schema.length) {
       if (!row.isNullAt(i)) {
-        values(i) = convertValue(valueConverters(i).apply(row, i), options)
+        values(i) = convertValue(valueConverters(i).apply(row, i), delimiter)
       } else {
         values(i) = "NULL"
       }
@@ -79,9 +80,7 @@ object GreenplumUtils extends Logging {
     (values.mkString(options.delimiter) + "\n").getBytes("UTF-8")
   }
 
-  def convertValue(str: String, options: GreenplumOptions): String = {
-    assert(options.delimiter.length == 1, "The delimiter should be a single character.")
-    val delimiter = options.delimiter.charAt(0)
+  def convertValue(str: String, delimiter: Char): String = {
     str.flatMap {
       case '\\' => "\\\\"
       case '\n' => "\\n"

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/PartitionCopyFailureException.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/PartitionCopyFailureException.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.greenplum
+
+/**
+ * General exception caused by some partition failed for copying dataFrame to greenplum.
+ */
+class PartitionCopyFailureException(
+    errorMsg: String,
+    cause: Throwable = null)
+  extends Exception(errorMsg, cause)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
@@ -262,7 +262,8 @@ class GreenplumUtilsSuite extends SparkFunSuite with MockitoSugar {
 
   def withConnectionAndOptions(f: (Connection, String, GreenplumOptions) => Unit ): Unit = {
     val paras =
-      CaseInsensitiveMap(Map("url" -> s"$url", "delimiter" -> "\t", "dbtable" -> "gptest"))
+      CaseInsensitiveMap(Map("url" -> s"$url", "delimiter" -> "\t", "dbtable" -> "gptest",
+      "transactionForAppend" -> "true"))
     val options = GreenplumOptions(paras, timeZoneId)
     val conn = JdbcUtils.createConnectionFactory(options)()
     try {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
@@ -200,7 +200,7 @@ class GreenplumUtilsSuite extends SparkFunSuite with MockitoSugar {
         schema.map(s => GreenplumUtils.makeConverter(s.dataType, options)).toArray
 
       val row = new GenericRow(values)
-      val str = GreenplumUtils.convertRow(row, schema, options, valueConverters)
+      val str = GreenplumUtils.convertRow(row, schema.length, options.delimiter, valueConverters)
       assert(str === "\\n\t\\\t\t,\t\\r\t\\\\\t\\\\n\n".getBytes("utf-8"))
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
@@ -194,7 +194,7 @@ class GreenplumUtilsSuite extends SparkFunSuite {
     val paras = CaseInsensitiveMap(Map("url" -> s"$url", "delimiter" -> "\t", "dbtable" -> "test"))
     val options = GreenplumOptions(paras, timeZoneId)
     val value = "test\t\rtest\n\\n\\,"
-    assert(GreenplumUtils.convertValue(value, options) === "test\\\t\\rtest\\n\\\\n\\\\,")
+    assert(GreenplumUtils.convertValue(value, '\t') === "test\\\t\\rtest\\n\\\\n\\\\,")
 
     val values = Array[Any]("\n", "\t", ",", "\r", "\\", "\\n")
     val schema = new StructType().add("c1", StringType).add("c2", StringType).add("c3", StringType)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add transactions support for transmitting data from sparkSql to greenplum.
There are several cases of data transmission:
- case1: Append data to origin gptable.
- case2: Overwrite origin gptable, but the table is a cascadingTruncateTable, so we can not drop the gptable, we have to truncate it and append data.
- case3: Overwrite origin table and the table is not a cascadingTruncateTable, so we can drop it.

I add a transactionOn option in GreenplumOptions, default is false.
The  copy operation to greenplum  for each partition is atomic.
For  case1 and case2, when transactionOn is true, we will coalesce the dataframe's partitions to one partition, then the operation of the only partition is an atomic operation.
Otherwise, the copy operation for all partitions is not in a single transaction.

For case3, we create a temp greenplum table, and copy each partition's data to the temp table.
We register an accmulator  to record the number of  successful operation, which copies a partition's data to temp table.
If all operations for each partition are successful,  we drop the gptable if it exists, and rename the temp table to gptable. 
Otherwise, there are some unsuccessful partitions, we will drop the temp table and throw an exception to notify the user.


## How was this patch tested?
Unit test.