### PR TITLE
[SPARK-GREENPLUM-5] Set a timeout for copy operation, which copies a partition's data to greenplum. #10

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -45,6 +45,10 @@ case class GreenplumOptions(
   /** Max number of times we are allowed to retry dropTempTable operation. */
   val dropTempTableMaxRetries: Int = 3
 
+  /** Timeout in minutes for copying a partition's data to greenplum. */
+  val copyTimeout = params.getOrElse("copyTimeout", "200").toInt
+  assert(copyTimeout > 0, "The copy timeout should be a positive number.")
+
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(
     params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -48,7 +48,7 @@ case class GreenplumOptions(
 
   /** Timeout for copying a partition's data to greenplum. */
   val copyTimeout = Utils.timeStringAsMs(params.getOrElse("copyTimeout", "1h"))
-  assert(copyTimeout > 0, "The copy timeout should be a positive number.")
+  assert(copyTimeout > 0, "The copy timeout should be positive, 10s, 10min, 1h etc.")
 
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(
     params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.time.FastDateFormat
 
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.util.Utils
 
 /**
  * Options for the Greenplum data source.
@@ -45,8 +46,8 @@ case class GreenplumOptions(
   /** Max number of times we are allowed to retry dropTempTable operation. */
   val dropTempTableMaxRetries: Int = 3
 
-  /** Timeout in minutes for copying a partition's data to greenplum. */
-  val copyTimeout = params.getOrElse("copyTimeout", "200").toInt
+  /** Timeout for copying a partition's data to greenplum. */
+  val copyTimeout = Utils.timeStringAsMs(params.getOrElse("copyTimeout", "1h"))
   assert(copyTimeout > 0, "The copy timeout should be a positive number.")
 
   val timeZone: TimeZone = DateTimeUtils.getTimeZone(

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -242,7 +242,7 @@ object GreenplumUtils extends Logging {
         while (checkCopyThread(start)) {
           Thread.sleep(1000)
         }
-        copyException.foreach(e => throw e)
+        copyException.foreach(throw _)
         if (!promisedCopyNums.isCompleted) {
           throw new TimeoutException(
             s"""

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -240,7 +240,7 @@ object GreenplumUtils extends Logging {
         val start = System.nanoTime()
         copyThread.start()
         while (checkCopyThread(start)) {
-          Thread.sleep(1000)
+          Thread.sleep(50)
         }
         copyException.foreach(throw _)
         if (!promisedCopyNums.isCompleted) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
I add a copyTimeout option to GreenplumOptions.
And for each partition, I start a copy thread and check the copy thread's state.
The exception of copy thread would be throwed and if the copy thread has been running for more than the copyTimeout, a timeout exception would be throwed.
Otherwise, the copy operation is completed in timeout.
## How was this patch tested?
Existing unit test.