### PR TITLE
[SPARK-GREENPLUM-7] Fix bug when rename table

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -125,7 +125,8 @@ object GreenplumUtils extends Logging {
         val dropTbl = s"DROP TABLE IF EXISTS ${options.table}"
         executeStatement(conn, dropTbl)
 
-        val renameTempTbl = s"ALTER TABLE $tempTable RENAME TO ${options.table}"
+        val newTableName = s"${options.table}".split("\\.").last
+        val renameTempTbl = s"ALTER TABLE $tempTable RENAME TO ${newTableName}"
         executeStatement(conn, renameTempTbl)
       } else {
         var retryCount = 0


### PR DESCRIPTION
The origin rename operation is wrong.
```
alter table schema.temptable rename to schema.newname
```
The correct way is:
```
alter table schema.temptable rename to newname
```
