### PR TITLE
[SPARK-GREENPLUM-9] Fix the bug when creating temp table.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -317,8 +317,13 @@ private[greenplum] object TableNameExtractor {
   def extract(tableName: String): CanonicalTblName = {
     tableName match {
       case nonSchemaTable(table) => CanonicalTblName(None, Some(table))
-      case schemaTable(schme, table) => CanonicalTblName(Some(schme), Some(table))
-      case _ => throw new IllegalArgumentException("The table name is illegal.")
+      case schemaTable(schema, table) => CanonicalTblName(Some(schema), Some(table))
+      case _ => throw new IllegalArgumentException(
+        s"""
+           | The table name is illegal, you can set it with the dbtable option, such as
+           | "schemaname"."tableName" or just "tableName" with a default schema "public".
+         """.stripMargin
+      )
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In a GreenplumOptions, if its table option is in a format that both schema and rawTableName are closured by double quotes.
Such as :
```
"schemaName"."tableName"
```
So we can not  append a randomString on the end of options.table directly.
## How was this patch tested?
Unit test.