### PR TITLE
Handle date/timestamp as java.sql.XX

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
@@ -36,8 +36,7 @@ class DefaultSource
       parameters: Map[String, String]): BaseRelation = {
     import JDBCOptions._
 
-    val options =
-      GreenplumOptions(CaseInsensitiveMap(parameters), sqlContext.conf.sessionLocalTimeZone)
+    val options = GreenplumOptions(CaseInsensitiveMap(parameters))
     val partitionColumn = options.partitionColumn
     val lowerBound = options.lowerBound
     val upperBound = options.upperBound
@@ -63,8 +62,7 @@ class DefaultSource
       mode: SaveMode,
       parameters: Map[String, String],
       df: DataFrame): BaseRelation = {
-    val options =
-      GreenplumOptions(CaseInsensitiveMap(parameters), sqlContext.conf.sessionLocalTimeZone)
+    val options = GreenplumOptions(CaseInsensitiveMap(parameters))
     val isCaseSensitive = sqlContext.conf.caseSensitiveAnalysis
 
     val conn = createConnectionFactory(options)()

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptions.scala
@@ -17,20 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources.greenplum
 
-import java.util.{Locale, TimeZone}
-
-import org.apache.commons.lang3.time.FastDateFormat
-
-import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.util.Utils
 
 /**
  * Options for the Greenplum data source.
  */
-case class GreenplumOptions(
-    @transient params: CaseInsensitiveMap[String],
-    defaultTimeZoneId: String)
+case class GreenplumOptions(@transient params: CaseInsensitiveMap[String])
   extends JDBCOptions(params.updated("driver", "org.postgresql.Driver")) {
 
   val delimiter: String = params.getOrElse("delimiter", ",")
@@ -49,15 +43,4 @@ case class GreenplumOptions(
   /** Timeout for copying a partition's data to greenplum. */
   val copyTimeout = Utils.timeStringAsMs(params.getOrElse("copyTimeout", "1h"))
   assert(copyTimeout > 0, "The copy timeout should be positive, 10s, 10min, 1h etc.")
-
-  val timeZone: TimeZone = DateTimeUtils.getTimeZone(
-    params.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
-
-  // Uses `FastDateFormat` which can be direct replacement for `SimpleDateFormat` and thread-safe.
-  val dateFormat: FastDateFormat =
-    FastDateFormat.getInstance(params.getOrElse("dateFormat", "yyyy-MM-dd"), Locale.US)
-
-  val timestampFormat: FastDateFormat =
-    FastDateFormat.getInstance(
-      params.getOrElse("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"), timeZone, Locale.US)
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -19,19 +19,19 @@ package org.apache.spark.sql.execution.datasources.greenplum
 
 import java.io._
 import java.nio.charset.StandardCharsets
-import java.sql.Connection
+import java.sql.{Connection, Date, Timestamp}
 import java.util.UUID
 import java.util.concurrent.{TimeoutException, TimeUnit}
 
-import org.postgresql.copy.CopyManager
-import org.postgresql.core.BaseConnection
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 
 import org.apache.spark.SparkEnv
+import org.postgresql.copy.CopyManager
+import org.postgresql.core.BaseConnection
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{LongAccumulator, ThreadUtils, Utils}
@@ -52,10 +52,9 @@ object GreenplumUtils extends Logging {
     case DecimalType() => (r: Row, i: Int) => r.getDecimal(i).toString
 
     case DateType =>
-      (r: Row, i: Int) => options.dateFormat.format(DateTimeUtils.toJavaDate(r.getInt(i)))
+      (r: Row, i: Int) => r.getAs[Date](i).toString
 
-    case TimestampType => (r: Row, i: Int) =>
-      options.timestampFormat.format(DateTimeUtils.toJavaTimestamp(r.getLong(i)))
+    case TimestampType => (r: Row, i: Int) => r.getAs[Timestamp](i).toString
 
     case BinaryType => (r: Row, i: Int) =>
       new String(r.getAs[Array[Byte]](i), StandardCharsets.UTF_8)

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptionsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumOptionsSuite.scala
@@ -27,65 +27,30 @@ import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 
 class GreenplumOptionsSuite extends SparkFunSuite with Matchers {
   private val date = new Date(0)
-  val timeZoneId: String = TimeZone.getDefault.getID
 
   test("empty user specified options") {
-    val e = intercept[IllegalArgumentException](GreenplumOptions(CaseInsensitiveMap(
-      Map()), timeZoneId))
+    val e = intercept[IllegalArgumentException](GreenplumOptions(CaseInsensitiveMap(Map())))
     e.getMessage should include("Option 'url' is required")
   }
 
   test("map with only url") {
-    val e = intercept[IllegalArgumentException](GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "")), timeZoneId))
+    val e = intercept[IllegalArgumentException](
+      GreenplumOptions(CaseInsensitiveMap(Map("url" -> ""))))
     e.getMessage should include("Option 'dbtable' is required")
   }
 
   test("driver class should always using postgresql") {
-    val options = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src")), timeZoneId)
+    val options = GreenplumOptions(CaseInsensitiveMap(Map("url" -> "", "dbtable" -> "src")))
     options.driverClass should be("org.postgresql.Driver")
     val options2 = GreenplumOptions(CaseInsensitiveMap(
       Map("url" -> "",
         "dbtable" -> "src",
-        "driver" -> "org.mysql.Driver")), timeZoneId)
+        "driver" -> "org.mysql.Driver")))
     options2.driverClass should be("org.postgresql.Driver")
   }
 
-  test("time zone") {
-    val options = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src")), timeZoneId)
-    options.timeZone should be(DateTimeUtils.getTimeZone(options.defaultTimeZoneId))
-    val tid = TimeZone.getTimeZone("PST").getID
-    val options2 = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src", "timeZone" -> tid)), timeZoneId)
-    options2.timeZone should be(DateTimeUtils.getTimeZone(tid))
-  }
-
-  test("date format") {
-    val options = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src")), timeZoneId)
-    options.dateFormat.format(date) should be("1970-01-01")
-    val options2 = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src", "dateFormat" -> "MM/dd/yyyy" )), timeZoneId)
-    options2.dateFormat.format(date) should be("01/01/1970")
-  }
-
-  test("time format") {
-    val options = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src")), timeZoneId)
-    val time1 = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(date)
-    options.timestampFormat.format(date) should be(time1)
-    val time2 = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss").format(date)
-    val options2 = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src",
-        "timestampFormat" -> "yyyy-MM-dd'T'HH:mm:ss" )), timeZoneId)
-    options2.timestampFormat.format(date) should be(time2)
-  }
-
   test("as properties") {
-    val options = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src")), timeZoneId)
+    val options = GreenplumOptions(CaseInsensitiveMap(Map("url" -> "", "dbtable" -> "src")))
     val properties = options.asProperties
     properties.getProperty("url") should be("")
     properties.get("dbtable") should be("src")
@@ -93,8 +58,7 @@ class GreenplumOptionsSuite extends SparkFunSuite with Matchers {
   }
 
   test("as connection properties") {
-    val options = GreenplumOptions(CaseInsensitiveMap(
-      Map("url" -> "", "dbtable" -> "src")), timeZoneId)
+    val options = GreenplumOptions(CaseInsensitiveMap(Map("url" -> "", "dbtable" -> "src")))
     val properties = options.asConnectionProperties
     properties.getProperty("url") should be(null)
     properties.get("dbtable") should be(null)


### PR DESCRIPTION
```scala
DE Error: (code=463)java.lang.RuntimeException: java.sql.SQLException: 
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 124.0 failed 4 times, most recent failure: Lost task 0.3 in stage 124.0 (TID 9530, hadoop4315.jd.163.org, executor 38): java.lang.ClassCastException: java.sql.Date cannot be cast to java.lang.Integer at 
 
scala.runtime.BoxesRunTime.unboxToInt(BoxesRunTime.java:101) at 
org.apache.spark.sql.Row$class.getInt(Row.scala:223) at 
org.apache.spark.sql.catalyst.expressions.GenericRow.getInt(rows.scala:166) 
```