### PR TITLE
[BUG] If there is an empty char in a row, drop it.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -88,6 +88,7 @@ object GreenplumUtils extends Logging {
       case '\n' => "\\n"
       case '\r' => "\\r"
       case `delimiter` => s"\\$delimiter"
+      case c if c == 0 => "" // If this char is an empty character, drop it.
       case c => s"$c"
     }
   }

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
@@ -137,8 +137,11 @@ class GreenplumUtilsSuite extends SparkFunSuite with MockitoSugar {
   test("test copy to greenplum") {
     withConnectionAndOptions { (conn, tblname, options) =>
       // scalastyle:off
-      val kvs = Map[Int, String](0 -> " ", 1 -> "\t", 2 -> "\n", 3 -> "\r", 4 -> "\\t",
-        5 -> "\\n", 6 -> "\\", 7 -> ",", 8 -> "te\tst", 9 -> "1`'`", 10 -> "中文测试")
+      val buffer = "测试".getBytes().toBuffer
+      buffer += 0
+      val strWithEmpty = new String(buffer.toArray)
+      val kvs = Map[Int, String](0 -> " ", 1 -> "\t", 2 -> "\n", 3 -> "\r", 4 -> "\\t", 5 -> "\\n",
+        6 -> "\\", 7 -> ",", 8 -> "te\tst", 9 -> "1`'`", 10 -> "中文测试", 11 -> strWithEmpty)
       // scalastyle:on
       val rdd = sparkSession.sparkContext.parallelize(kvs.toSeq)
       val df = sparkSession.createDataFrame(rdd)
@@ -154,7 +157,7 @@ class GreenplumUtilsSuite extends SparkFunSuite with MockitoSugar {
         val k = result2.getInt(1)
         val v = result2.getString(2)
         count += 1
-        assert(kvs(k) === v)
+        assert(kvs(k).filterNot(_ == 0) === v)
       }
       assert(count === kvs.size)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

There may be some empty characters in columns.
If we save them into file  without cleaning,  an exception will be thrown when copying the data of file into greenplum.
```
Caused by: org.postgresql.util.PSQLException: ERROR: invalid byte sequence for encoding "UTF8": 0x00
```
In this PR, we drop these empty characters, which are meaningless and fatal.
### How was this patch tested?
Unit test and manual test.