### PR TITLE
[BUG]  Remove unused checkSchema and reorderDataFrame and add  a rule to check the columns names of gp table and sub query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Also, this library is fully **transactional** .
 
 ## Try it now !
 
+### Configuration
+We add a rule to check the column names of greenplum table and spark sql query.
+You can set it as below.
+
+```
+spark.sql.extensions=org.apache.spark.sql.catalyst.analysis.GreenPlumColumnCheckerExtension
+```
+
 ### CTAS
 ```genericsql
 CREATE TABLE tbl

--- a/src/main/scala/org/apache/spark/sql/catalyst/analysis/GreenPlumColumnCheckerExtension.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/analysis/GreenPlumColumnCheckerExtension.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.execution.datasources.InsertIntoDataSourceCommand
+import org.apache.spark.sql.execution.datasources.greenplum.GreenplumRelation
+
+case class GreenPlumColumnChecker(spark: SparkSession) extends (LogicalPlan => Unit) with Logging {
+  override def apply(plan: LogicalPlan): Unit = {
+    if (plan.isInstanceOf[InsertIntoDataSourceCommand]) {
+      val command = plan.asInstanceOf[InsertIntoDataSourceCommand]
+      val logicRelation = command.logicalRelation
+      val baseRelation = logicRelation.relation
+      if (baseRelation.isInstanceOf[GreenplumRelation]) {
+        val relationOutput = logicRelation.output
+        if (command.query.isInstanceOf[Project]) {
+          // This is the real output of sub query, which is not be casted.
+          val realOutput = command.query.asInstanceOf[Project].child.output
+          if (relationOutput.size != realOutput.size ||
+          relationOutput.zip(realOutput).exists(ats => ats._1.name != ats._2.name)) {
+            throw new AnalysisException(
+              s"""
+                 | The column names of GreenPlum table are not consistent with the
+                 | projects output names of subQuery.
+             """.stripMargin)
+          }
+        }
+        logInfo(s"GreenPlumColumnChecker: check passed.")
+      }
+    }
+  }
+}
+
+class GreenPlumColumnCheckerExtension extends (SparkSessionExtensions => Unit) {
+  override def apply(e: SparkSessionExtensions): Unit = {
+    e.injectCheckRule(GreenPlumColumnChecker)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/DefaultSource.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.jdbc._
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister, RelationProvider}
-import org.apache.spark.sql.types.StructType
 
 class DefaultSource
   extends RelationProvider with CreatableRelationProvider with DataSourceRegister {
@@ -62,27 +61,22 @@ class DefaultSource
       parameters: Map[String, String],
       df: DataFrame): BaseRelation = {
     val options = GreenplumOptions(CaseInsensitiveMap(parameters))
-    val isCaseSensitive = sqlContext.conf.caseSensitiveAnalysis
-
     val conn = JdbcUtils.createConnectionFactory(options)()
     try {
       if (tableExists(conn, options.table)) {
-        val tableSchema = JdbcUtils.getSchemaOption(conn, options)
-        checkSchema(tableSchema, df.schema, isCaseSensitive)
-        val orderedDf = reorderDataFrameColumns(df, tableSchema)
         // In fact, the mode here is Overwrite constantly, we add other modes just for compatible.
         mode match {
           case SaveMode.Overwrite
             if options.isTruncate &&
               JdbcUtils.isCascadingTruncateTable(options.url).contains(false) =>
             JdbcUtils.truncateTable(conn, options)
-            nonTransactionalCopy(if (options.transactionOn) orderedDf.coalesce(1) else orderedDf,
-              orderedDf.schema, options)
+            nonTransactionalCopy(if (options.transactionOn) df.coalesce(1) else df,
+              df.schema, options)
           case SaveMode.Overwrite =>
-            transactionalCopy(orderedDf, orderedDf.schema, options)
+            transactionalCopy(df, df.schema, options)
           case SaveMode.Append =>
-            nonTransactionalCopy(if (options.transactionOn) orderedDf.coalesce(1) else orderedDf,
-              orderedDf.schema, options)
+            nonTransactionalCopy(if (options.transactionOn) df.coalesce(1) else df,
+              df.schema, options)
           case SaveMode.ErrorIfExists =>
             throw new AnalysisException(s"Table or view '${options.table}' already exists. $mode")
           case SaveMode.Ignore => // do nothing
@@ -94,24 +88,5 @@ class DefaultSource
       closeConnSilent(conn)
     }
     createRelation(sqlContext, parameters)
-  }
-
-  private def checkSchema(
-      tableSchema: Option[StructType],
-      dfSchema: StructType,
-      isCaseSensitive: Boolean): Unit = {
-    if (!tableSchema.isEmpty) {
-      val columnNameEquality = if (isCaseSensitive) {
-        org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution
-      } else {
-        org.apache.spark.sql.catalyst.analysis.caseInsensitiveResolution
-      }
-      val tableColumnNames = tableSchema.get.fieldNames
-      dfSchema.fields.map { col =>
-        tableColumnNames.find(f => columnNameEquality(f, col.name)).getOrElse(
-          throw new AnalysisException(s"Column ${col.name} not found int schema $tableSchema.")
-        )
-      }
-    }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -298,12 +298,6 @@ object GreenplumUtils extends Logging {
     }
   }
 
-  def reorderDataFrameColumns(df: DataFrame, tableSchema: Option[StructType]): DataFrame = {
-    tableSchema.map { schema =>
-      df.selectExpr(schema.map(filed => filed.name): _*)
-    }.getOrElse(df)
-  }
-
   /**
    * Returns true if the table already exists in the JDBC database.
    */

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtilsSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.greenplum
 
 import java.io.File
 import java.sql.{Connection, Date, SQLException, Timestamp}
-import java.util.TimeZone
 
 import scala.concurrent.TimeoutException
 
@@ -27,8 +26,8 @@ import io.airlift.testing.postgresql.TestingPostgreSqlServer
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
-import org.apache.spark.SparkFunSuite
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.api.java.function.ForeachPartitionFunction
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.GenericRow


### PR DESCRIPTION
### What is proposed in this PR?
The code of chechSchema and reorderDataFrame are not useful.
The schema of dataFrame is always same with the gpTable, because the subQuery's column names would be casted to the corresponding column names of gptable.
So we remove the code of chechSchema and reorderDataFrame and add a rule to check whether the column names are same with the real columns name of sub query.



