### PR TITLE
[BUG] Remove unused checkSchema and reorderDataFrame and add a rule to check the columns names of gp table and sub query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ INSERT INTO TABLE tbl SELECT * FROM tpcds_100g.store_sales WHERE ss_sold_date_sk
 ```
 #### Configuration
 
-When we using `View & Insert` to write data into GreenPlum,
-we need to create a gp table firstly, and then create the relative temporary spark table, whose schema is same with the gp table.
-When inserting the sub query's data into the temporary spark table, we may need to check whether the schema of sub query
-is consistent with that of gp table.
+If we use `View & Insert` to write data into GreenPlum, we need to create a gp table firstly, and then create the relative temporary spark table, whose schema is same with the gp table.
+When inserting the sub query's data into the temporary spark table, we may need to check whether the schema of sub query is consistent with that of gp table.
 Therefore, we add a rule to check it.
 You can set it as below.
 

--- a/README.md
+++ b/README.md
@@ -39,5 +39,17 @@ options (
 INSERT INTO TABLE tbl SELECT * FROM tpcds_100g.store_sales WHERE ss_sold_date_sk<=2451537 AND ss_sold_date_sk> 2451520;
 
 ```
+#### Configuration
+
+When we using `View & Insert` to write data into GreenPlum,
+we need to create a gp table firstly, and then create the relative temporary spark table, whose schema is same with the gp table.
+When inserting the sub query's data into the temporary spark table, we may need to check whether the schema of sub query
+is consistent with that of gp table.
+Therefore, we add a rule to check it.
+You can set it as below.
+
+```
+spark.sql.extensions=org.apache.spark.sql.catalyst.analysis.GreenPlumColumnCheckerExtension
+```
 
 Please refer to [Spark SQL Guide - JDBC To Other Databases](http://spark.apache.org/docs/latest/sql-data-sources-jdbc.html) to learn more about the similar usage. 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.ver}</artifactId>
+            <version>${spark.ver}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/io.airlift/testing-postgresql-server -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/src/main/scala/org/apache/spark/sql/catalyst/analysis/GreenPlumColumnCheckerExtension.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/analysis/GreenPlumColumnCheckerExtension.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.execution.datasources.{InsertIntoDataSourceCommand, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.greenplum.GreenplumRelation
+
+case class GreenPlumColumnChecker(spark: SparkSession) extends (LogicalPlan => Unit) with Logging {
+  override def apply(plan: LogicalPlan): Unit = plan match {
+    case InsertIntoDataSourceCommand(LogicalRelation(_: GreenplumRelation, output, _, _),
+    Project(_, c), _) =>
+      // The real output of sub query, which is not be casted.
+      val realOutput = c.output
+      if (realOutput.size != output.size || realOutput.zip(output).exists(
+        ats => ats._1.name != ats._2.name)) {
+        throw new AnalysisException(
+          s"""
+             | The column names of GreenPlum table are not consistent with the
+             | projects output names of subQuery.
+           """.stripMargin)
+      }
+    case InsertIntoDataSourceCommand(LogicalRelation(_: GreenplumRelation, _, _, _), query, _) =>
+      logWarning(s"GreenPlumColumnChecker: The query of this GreenPlumRelation " +
+        s"is a ${query.getClass.getName}.")
+    case _ =>
+  }
+}
+
+class GreenPlumColumnCheckerExtension extends (SparkSessionExtensions => Unit) {
+  override def apply(e: SparkSessionExtensions): Unit = {
+    e.injectCheckRule(GreenPlumColumnChecker)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/greenplum/GreenplumUtils.scala
@@ -298,12 +298,6 @@ object GreenplumUtils extends Logging {
     }
   }
 
-  def reorderDataFrameColumns(df: DataFrame, tableSchema: Option[StructType]): DataFrame = {
-    tableSchema.map { schema =>
-      df.selectExpr(schema.map(filed => filed.name): _*)
-    }.getOrElse(df)
-  }
-
   /**
    * Returns true if the table already exists in the JDBC database.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?
The code of chechSchema and reorderDataFrame are not useful.
The schema of dataFrame is always same with the gpTable, because the subQuery's column names would be casted to the corresponding column names of gptable.
So we remove the code of chechSchema and reorderDataFrame and add a rule to check whether the column names are same with the real columns name of sub query.

### How was this patch tested?

Unit test and manual test.